### PR TITLE
dependency manager - eternal operations

### DIFF
--- a/src/DSPolitical/DependencyGraph/Node.php
+++ b/src/DSPolitical/DependencyGraph/Node.php
@@ -25,6 +25,11 @@ class Node
     private $started = false;
 
     /**
+     * @var bool
+     */
+    private $executed = false;
+
+    /**
      * @param Operation $operation
      */
     public function __construct(Operation $operation)
@@ -88,5 +93,15 @@ class Node
     public function isStarted()
     {
         return $this->started;
+    }
+
+    public function setExecuted($executed = true)
+    {
+        $this->executed = $executed;
+    }
+
+    public function isExecuted()
+    {
+        return $this->executed;
     }
 }


### PR DESCRIPTION
The default behavior of this library is to remove a dependency operation (for our purposes, an API call/remote object) from the graph once the operation has been executed. I would like to be able to pull an array of all operations, executed and unexecuted, so that we can transform it into a front-end displayable data structure. Rather than futz with any other legacy handling here, I've added a parallel data member "eternalNodes" which gets all the same handling except for "Executed".